### PR TITLE
Update gol script

### DIFF
--- a/bin/gol
+++ b/bin/gol
@@ -1,3 +1,11 @@
-#!/bin/bash
-scriptDir=$(dirname -- "$(readlink -f -- "$BASH_SOURCE")")
-java -cp $scriptDir/../lib/gol.jar com.geodesk.gol.GolTool "$@"
+#!/usr/bin/env bash
+
+SOURCE=${BASH_SOURCE[0]}
+while [ -L "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+  DIR=$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )
+  SOURCE=$(readlink "$SOURCE")
+  [[ $SOURCE != /* ]] && SOURCE=$DIR/$SOURCE # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+done
+DIR=$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )
+
+java -cp $DIR/../lib/gol.jar com.geodesk.gol.GolTool "$@"


### PR DESCRIPTION
Fix issue for symlinked `gol` script on macos/unix:

```sh
$ ./gol                                                                                                                                                                                                          
readlink: illegal option -- f
usage: readlink [-n] [file ...]
Fehler: Hauptklasse com.geodesk.gol.GolTool konnte nicht gefunden oder geladen werden
Ursache: java.lang.ClassNotFoundException: com.geodesk.gol.GolTool
```

Source from <https://stackoverflow.com/a/246128/211514>.